### PR TITLE
Check whether vignette has any thumbnailer backend

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,6 +20,7 @@ Internal changes
 Bug fixes and minor changes
 ---------------------------
 
++ `#54`_: Check whether vignette has any thumbnailer backend.
 + `#49`_: Fix :exc:`DeprecationWarning` about importing the ABCs from
   :mod:`collections`.
 
@@ -30,6 +31,7 @@ Bug fixes and minor changes
 .. _#51: https://github.com/RKrahl/photoidx/pull/51
 .. _#52: https://github.com/RKrahl/photoidx/issues/52
 .. _#53: https://github.com/RKrahl/photoidx/pull/53
+.. _#54: https://github.com/RKrahl/photoidx/pull/54
 
 
 0.9.3 (2020-05-03)

--- a/README.rst
+++ b/README.rst
@@ -40,6 +40,10 @@ Optional library packages:
   vignette is not available, everything will still work, but
   displaying the overview window may be significantly slower.
 
++ vignette needs at least one thumbnail backend, either `Pillow`_ or
+  `PyQt5`_.  If no suitable backend is found, vignette will be
+  disabled in photoidx.
+
 + `setuptools_scm`_
 
   The version number is managed using this package.  All source
@@ -83,6 +87,8 @@ permissions and limitations under the License.
 .. _exif: https://github.com/TNThieding/exif
 .. _PySide: https://wiki.qt.io/PySide
 .. _vignette: https://github.com/hydrargyrum/vignette
+.. _Pillow: https://python-pillow.org/
+.. _PyQt5: https://www.riverbankcomputing.com/software/pyqt/
 .. _setuptools_scm: https://github.com/pypa/setuptools_scm/
 .. _pytest: https://pytest.org/
 .. _pytest-dependency: https://github.com/RKrahl/pytest-dependency

--- a/photoidx/qt/image.py
+++ b/photoidx/qt/image.py
@@ -1,12 +1,15 @@
 """Provide the class Image corresponding to an IdxItem.
 """
 
+import logging
 import re
 from PySide import QtCore, QtGui
 try:
     import vignette
 except ImportError:
     vignette = None
+
+log = logging.getLogger(__name__)
 
 # Limit the vignette thumbnailer backends to those dealing with images.
 if vignette:
@@ -23,6 +26,11 @@ if vignette:
             ]
         else:
             # vignette is too old to be usable
+            vignette = None
+    if vignette:
+        if not list(vignette.iter_thumbnail_backends()):
+            log.warning("Disabling vignette: "
+                        "no suitable thumbnailer backend available")
             vignette = None
 
 


### PR DESCRIPTION
Add a check whether `vignette` has any working thumbnailer backend available and disable `vigentte` if that is not the case.